### PR TITLE
update download/styles

### DIFF
--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -53,9 +53,6 @@ git instructions
 Styles are available on several sites on the Internet. The biggest style
 repositories are:
 
-* tenr.de
-* box-look.org
-* http://themes.freshmeat.net
-* klowner's site
-* deviantart
-* customize.org
+* [tenr.de](http://tenr.de/styles)
+* [box-look.org](https://www.box-look.org/browse?cat=139&ord=latest)
+* [dotshare.it](http://dotshare.it/category/wms/fluxbox/)


### PR DESCRIPTION
the missing url's are down or sites were rewritten as such the original links won't work anymore (deviantart) - https://web.archive.org/web/20200617055912/http://www.fluxbox.org/download/
render all url's by [defining them](https://gohugo.io/render-hooks/links/)
dotshare doesn't have much but imo worth a link for fluxbox users in general.